### PR TITLE
Tests were not passing on Windows - fixed cases where it failed

### DIFF
--- a/db.go
+++ b/db.go
@@ -172,7 +172,6 @@ func (c *C) SelectEach(fn func(int, []byte) (include bool, data []byte, stop boo
 	}
 	tempfilename := tempfile.Name()
 	defer func() {
-		tempfile.Close()
 		os.Remove(tempfilename)
 	}()
 	f, err := c.file()
@@ -201,6 +200,10 @@ func (c *C) SelectEach(fn func(int, []byte) (include bool, data []byte, stop boo
 	}
 	c.close()
 	os.Remove(c.path)
+	err = tempfile.Close()
+	if err != nil {
+		return err
+	}
 	err = os.Rename(tempfilename, c.path)
 	if err != nil {
 		return err

--- a/db_test.go
+++ b/db_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/matryer/filedb"
@@ -40,7 +41,7 @@ func TestC(t *testing.T) {
 	c, err := db.C("TestCDB")
 	require.NoError(t, err)
 	require.NotNil(t, c)
-	require.Equal(t, c.Path(), "test/db/TestCDB.filedb")
+	require.Equal(t, c.Path(), filepath.Join("test", "db", "TestCDB.filedb"))
 	require.Equal(t, c.DB(), db)
 
 	// same C

--- a/db_test.go
+++ b/db_test.go
@@ -17,6 +17,7 @@ func setup() {
 }
 
 func TestDial(t *testing.T) {
+	setup()
 
 	db, err := filedb.Dial("test/missing")
 	require.Equal(t, err, filedb.ErrDBNotFound)
@@ -34,6 +35,7 @@ func TestDial(t *testing.T) {
 }
 
 func TestC(t *testing.T) {
+	setup()
 
 	db, err := filedb.Dial("test/db")
 	require.NoError(t, err)
@@ -76,6 +78,7 @@ func TestCollections(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
+	setup()
 
 	db, err := filedb.Dial("test/db")
 	require.NoError(t, err)
@@ -90,6 +93,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestSelectEach(t *testing.T) {
+	setup()
 
 	db, err := filedb.Dial("test/db")
 	require.NoError(t, err)
@@ -121,6 +125,7 @@ func TestSelectEach(t *testing.T) {
 }
 
 func TestForEach(t *testing.T) {
+	setup()
 
 	db, err := filedb.Dial("test/db")
 	require.NoError(t, err)
@@ -147,6 +152,8 @@ func TestForEach(t *testing.T) {
 }
 
 func TestDrop(t *testing.T) {
+	setup()
+
 	db, err := filedb.Dial("test/db")
 	require.NoError(t, err)
 	defer db.Close()
@@ -155,6 +162,7 @@ func TestDrop(t *testing.T) {
 }
 
 func TestRemoveEach(t *testing.T) {
+	setup()
 
 	db, err := filedb.Dial("test/db")
 	require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/matryer/filedb"
+	"github.com/kompiuter/filedb"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Failed on the following tests:

- `TestC`: Due to hard coded filepath separators -> now using `filepath.Join`

- `TestSelectEach`: Rename not allowed before closing `tempfile` -> now closing tempfile instead of closing at end of fn at deferred call, and checking error

- `TestRemoveEach`: Due to `SelectEach` being broken 